### PR TITLE
Fix blog header scroll prop

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -128,9 +128,8 @@ export default function BlogPage() {
 
     return (
         <>
-            <Header activeSection={''} scrollToSection={function (): void {
-                throw new Error('Function not implemented.');
-            }} />
+            {/* Header does not need scroll functionality on this page */}
+            <Header activeSection={''} />
             
             {/* Replace the old Page Banner with our new BannerSlider */}
             <BannerSlider />


### PR DESCRIPTION
## Summary
- remove leftover `scrollToSection` stub in blog page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fda4227388321bce6e64bfade430e